### PR TITLE
changed .tooltip-action max-width to just width of 370px

### DIFF
--- a/src/components/ActionTooltip.vue
+++ b/src/components/ActionTooltip.vue
@@ -268,7 +268,7 @@ export default {
 }
 
 .xivtooltip-action {
-  max-width: 370px;
+  width: 370px;
   height: auto;
   font-family: sans-serif;
   display: block;


### PR DESCRIPTION
very smol change that hopefully fixes the width being tiny when a parent has a set width.